### PR TITLE
Fixing search results

### DIFF
--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -5,11 +5,16 @@ class Api::V1::AreasController < Api::V1::BaseController
 
   def show
     @post_code = params[:query]
+    counter = -1
     @area = Area.find_by post_code: @post_code
-    # need a route if it doesn't find the post_code, maybe target the
-    # first 3 numbers and return all the available? for Tokyo it's very
-    # broad, some of them have 4 numbers so get that first, otherwise the
-    # first 3
+    if @area.nil?
+      until @area.nil? == false
+        @area = Area.find_by post_code: @post_code
+        @post_code[counter] = "0"
+        counter = counter -1
+      end
+      @area
+    end
     authorize @area
   end
 end

--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -8,7 +8,8 @@ class Api::V1::AreasController < Api::V1::BaseController
     @area = Area.find_by post_code: @post_code
     # need a route if it doesn't find the post_code, maybe target the
     # first 3 numbers and return all the available? for Tokyo it's very
-    # broad
+    # broad, some of them have 4 numbers so get that first, otherwise the
+    # first 3
     authorize @area
   end
 end


### PR DESCRIPTION
Modified the areas controller for #show to be able to provide with the closest result that it can find.
It picks the query and searches for the area, if there is no result it will loop until there is a match by changing the last digits to 0 from the end progressively and return the match as soon as there is one.
Tried with random places from google maps and it seems to be working.